### PR TITLE
catch failed oauth callbacks

### DIFF
--- a/src/routes/auth/providers/utils.ts
+++ b/src/routes/auth/providers/utils.ts
@@ -89,7 +89,11 @@ const providerCallback = async (req: Request, res: Response): Promise<void> => {
   // However, we send account data.
   const account = req.user as AccountData
 
-  await setRefreshToken(res, account.id)
+  try {
+    await setRefreshToken(res, account.id)
+  } catch(e) {
+    res.redirect(PROVIDER_FAILURE_REDIRECT as string)
+  }
 
   // redirect back user to app url
   res.redirect(PROVIDER_SUCCESS_REDIRECT as string)


### PR DESCRIPTION
this fixes an edge case - if you register a regular user account with 'a@b.com', and then later try to sign in with the same email using an oauth provider, setRefreshToken will throw because of the db error:
ERROR:  duplicate key value violates unique constraint "accounts_email_key"

this causes the oauth flow to hang and eventually time out.

Instead, we should just redirect to the failure URI for now